### PR TITLE
Avoid crashing bot dependency auto-updates

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -8,4 +8,6 @@ conda_build:
 conda_forge_output_validation: true
 bot:
   automerge: true
-  inspection: update-all
+  # Keep dependency analysis in version PRs, but avoid the v1 recipe dependency
+  # auto-edit path that currently crashes on exact-string dependency mismatches.
+  inspection: hint-all


### PR DESCRIPTION
## Summary

- switch bot dependency inspection from `update-all` to `hint-all`
- keep dependency analysis visible in future version PRs, but avoid the post-migration dependency auto-edit path that is currently crashing for this v1 recipe
- document the workaround next to the bot setting

## Bot failure before this patch

The autotick bot is discovering new `viser` releases, but it fails before it can open the version PR. Public bot-data for `viser` currently records:

- `new_version: 1.0.30`
- `new_version_attempts["1.0.30"]: 13`
- latest recorded failing run: https://github.com/conda-forge/conda-forge-bot/actions/runs/28255386331
- bot-data file: `version_pr_info/c/b/d/7/4/viser.json` in `conda-forge/conda-forge-bot-data`

The recorded pre-patch failure is:

```pytb
Traceback (most recent call last):
  File "/opt/conda-forge-bot/conda_forge_tick/container_cli.py", line 119, in _run_bot_task
    data = func(attrs=attrs, **kwargs)
  File "/opt/conda-forge-bot/conda_forge_tick/container_cli.py", line 235, in _migrate_feedstock
    data = run_migration_local(...)
  File "/opt/conda-forge-bot/conda_forge_tick/migration_runner.py", line 276, in run_migration_local
    migrator.run_post_piggyback_migrations(recipe_dir, feedstock_ctx.attrs, **kwargs)
  File "/opt/conda-forge-bot/conda_forge_tick/migrators/core.py", line 608, in run_post_piggyback_migrations
    mini_migrator.migrate(recipe_dir, attrs, **kwargs)
  File "/opt/conda-forge-bot/conda_forge_tick/migrators/dep_updates.py", line 67, in migrate
    apply_dep_update(...)
  File "/opt/conda-forge-bot/conda_forge_tick/update_deps.py", line 831, in apply_dep_update
    if (new_recipe := _apply_dep_update_v1(recipe, dep_comparison)) != recipe:
  File "/opt/conda-forge-bot/conda_forge_tick/update_deps.py", line 805, in _apply_dep_update_v1
    new_recipe["requirements"][section] = _apply_env_dep_comparison(...)
  File "/opt/conda-forge-bot/conda_forge_tick/update_deps.py", line 784, in _apply_env_dep_comparison
    new_deps.remove(patch.before)
ValueError
```

This matches open conda-forge-bot issues such as conda-forge/conda-forge-bot#5996 and conda-forge/conda-forge-bot#6255.

## Why this resolves the root cause

I reproduced the local control-flow/root-cause shape with the `viser` dependency comparison recorded in the bot log for the `1.0.30` attempt:

```
mode=update-all
  post-migration dependency auto-edit: runs
old update-all path tries exact remove: 'tqdm'
  reproduces root crash: ValueError
mode=hint-all
  post-migration dependency auto-edit: skipped
current conda-forge.yml inspection=hint-all
current config reaches crashing updater? False
```

The key bot behavior is:

- `DependencyUpdateMigrator.filter()` only runs the post-migration dependency auto-edit for `update-all`, `update-source`, and `update-grayskull`.
- `hint-all` skips that auto-edit migrator, so it no longer reaches the crashing `new_deps.remove(...)` path.
- `Version._hint_and_maybe_update_deps()` still permits dependency hint generation for non-`disabled` inspection modes, so version PRs can keep dependency analysis without mutating dependency lists.

## Validation

- `python - <<PY ...` YAML parse check confirms `bot.inspection == "hint-all"`
- `git diff --check`
- `conda-smithy recipe-lint --conda-forge recipe`
- PR CI: `linux_64_` and `conda-forge-linter` are green for head `39b92addc70e34c418d36304b212d21bd927b27f`
